### PR TITLE
Commands

### DIFF
--- a/commands/dbutils.py
+++ b/commands/dbutils.py
@@ -1,0 +1,92 @@
+from flask import current_app
+from flask.ext.script import Manager
+from flask.ext.migrate import Migrate, upgrade as migrate_upgrade
+
+from commands.utils import perform
+from project.fixtures import load_fixtures
+
+
+class _DBUtilsConfig(object):
+
+    def __init__(self, db):
+        self.db = db
+
+    @property
+    def metadata(self):
+        return self.db.metadata
+
+
+class DBUtils(object):
+
+    def __init__(self, app=None, db=None):
+        if app is not None and db is not None:
+            self.init_app(app, db)
+
+    def init_app(self, app, db):
+        if not hasattr(app, 'extensions'):
+            app.extensions = {}
+        app.extensions['meowth_dbutils'] = _DBUtilsConfig(db)
+        Migrate(app, db)
+
+
+DBUtilsCommand = Manager(usage='Perform basic dev database operations')
+
+
+@DBUtilsCommand.command
+def drop():
+    engine = current_app.extensions['meowth_dbutils'].db.engine
+    if current_app.extensions['meowth_dbutils'].metadata.bind is None:
+        current_app.extensions['meowth_dbutils'].metadata.bind = engine
+    with perform(
+        name='dbutils drop',
+        before='Dropping all project tables',
+        fail='Error occured while droping project tables',
+    ):
+        current_app.extensions['meowth_dbutils'].metadata.drop_all()
+    with perform(
+        name='dbutils drop',
+        before='Dropping alembic versioning table',
+        fail='Error occured while dropping alembic table',
+    ):
+        engine.execute('drop table if exists alembic_version')
+
+
+@DBUtilsCommand.option(
+    '-p', '--populate',
+    dest='populate_after_init',
+    action='store_true',
+    default=False,
+    help='Populate fixtures after creating database',
+)
+@DBUtilsCommand.option(
+    '-d', '--directory',
+    dest='directory',
+    default=None,
+    help='Directory to search fixtures in',
+)
+def init(populate_after_init=False, directory=None):
+    drop()
+    with perform(
+        name='dbutils init',
+        before='initializing database to its latest version',
+    ):
+        migrate_upgrade()
+    if populate_after_init:
+        populate(directory)
+
+
+@DBUtilsCommand.option(
+    '-d', '--directory',
+    dest='directory',
+    default=None,
+    help='Directory to search fixtures in',
+)
+def populate(directory=None):
+    if directory is None:
+        directory = current_app.config['FIXTURES_DIR']
+    with perform(
+        name='dbutils populate',
+        before='Loading fixtures from directory %s' % directory,
+        fail='Error occured while loading fixtures',
+    ):
+        load_fixtures(directory)

--- a/commands/static.py
+++ b/commands/static.py
@@ -1,0 +1,71 @@
+from flask.ext.script import Manager
+from subprocess import call
+from commands.utils import perform
+
+import os
+
+
+def alt_exec(cmd, alt=None):
+    """
+    Tries to execute command.
+    If command not found, it tries to execute the alternative comand
+    """
+    try:
+        call(cmd)
+    except OSError as e:
+        if e.errno == os.errno.ENOENT and alt:
+            try:
+                call(alt)
+            except OSError as ex:
+                raise ex
+        else:
+            raise e
+
+StaticCommand = Manager(usage='Commands to build static')
+
+
+@StaticCommand.option(
+    '--noinput',
+    dest='noinput',
+    action='store_true',
+    default=False,
+    help='Do not ask user anything',
+)
+def npm(noinput=False):
+    """ Run npm install script """
+    with perform(
+        name='static npm',
+        before='run npm install',
+    ):
+        cmd = ["npm", "install"]
+        if noinput:
+            cmd.append("--noinput")
+        alt_exec(
+            cmd=cmd,
+        )
+
+
+@StaticCommand.command
+def bower():
+    """ Run bower install script """
+    with perform(
+        name='static bower',
+        before='run bower install',
+    ):
+        alt_exec(
+            cmd=["bower", "install"],
+            alt=["./node_modules/bower/bin/bower", "install"],
+        )
+
+
+@StaticCommand.command
+def gulp():
+    """ Run gulp build script """
+    with perform(
+        name='static gulp',
+        before='run gulp',
+    ):
+        alt_exec(
+            cmd=["gulp"],
+            alt=["./node_modules/gulp/bin/gulp.js"],
+        )

--- a/commands/static.py
+++ b/commands/static.py
@@ -69,3 +69,16 @@ def gulp():
             cmd=["gulp"],
             alt=["./node_modules/gulp/bin/gulp.js"],
         )
+
+
+@StaticCommand.command
+def clean():
+    """ Clean built static files """
+    with perform(
+        name='static clean',
+        before='run gulp clean',
+    ):
+        alt_exec(
+            cmd=["gulp", "clean"],
+            alt=["./node_modules/gulp/bin/gulp.js", "clean"],
+        )

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -1,0 +1,45 @@
+from contextlib import contextmanager
+
+"""
+
+Borrowed from
+https://github.com/Orhideous/twicher/blob/master/twicher/utils.py
+
+"""
+
+COLORS = {
+    'BLUE': '\033[94m',
+    'GREEN': '\033[92m',
+    'ORANGE': '\033[93m',
+    'RED': '\033[91m',
+    'END': '\033[0m',
+    'BOLD': '\033[1m',
+    'UNDERLINE': '\033[4m'
+}
+
+
+@contextmanager
+def perform(
+    name='perform',
+    before=None,
+    fail='Fail',
+    after=None,
+):
+    format_args = dict(
+        COLORS,
+        name=name,
+        before=before,
+        fail=fail,
+        after=after,
+    )
+    if (before is not None):
+        print("{BLUE}[{name}]{END} {before}".format(**format_args))
+    try:
+        yield
+    except Exception as e:
+        print("{RED}[{name}]{END} {fail}".format(**format_args))
+        print("{RED}[{name}]{END} Reason: {e}".format(e=e, **format_args))
+        exit(1)
+    else:
+        if (after is not None):
+            print("{GREEN}[{name}]{END} {after}".format(**format_args))


### PR DESCRIPTION
# Refactored manage scripts structure
## Changelog
- Separated commands into modules:
  - dbutils (database initialization, populating db w/ fixtures, dropping db)
  - static (performing `npm`, `bower` and `gulp` commands)
- Replaced `wrap_logging` with more beautiful `perform` contextmanager. This context manager (`perform`) was borrowed from [[here]](https://github.com/Orhideous/twicher/blob/master/twicher/utils.py) and was modified a little
- Database utils now affected w/ migrations:
  - `dbutils init` uses migrate scripts
  - `dbutils drop` also drops the migration table
- Instead of having two scripts `init_db` and `init_empty_db` the `dbutils init` script is used. Pass the `--populate` (or `-p`) parameter to populate database after creation.
- `./mange.py collectstatic` scripts was left for backwards compatability, but was rewritten.