### PR TITLE
fix #150

### DIFF
--- a/project/bl/uploads.py
+++ b/project/bl/uploads.py
@@ -59,6 +59,8 @@ class UploadedImageBL(BaseBL):
         )
         thumbnail = category_dir / 'thumb' / name
         fullsized = category_dir / 'full' / name
-        thumbnail.unlink()
-        fullsized.unlink()
+        if thumbnail.exists():
+            thumbnail.unlink()
+        if fullsized.exists():
+            fullsized.unlink()
         super().delete()


### PR DESCRIPTION
This PR fixes issue #150 
If there is no related file(s) in filesystem, deletion will pass silently without `unlinking` non-existent files.