### PR TITLE
Drop exec-sync dependency

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,7 +11,7 @@ var source = require('vinyl-source-stream');
 var stylus = require('gulp-stylus');
 var uglify = require('gulp-uglify');
 var pkginfo = require('./package.json');
-var exec_sync = require('exec-sync');
+var child_process = require('child_process');
 
 var debug = gutil.env.type !== 'production';
 
@@ -26,12 +26,12 @@ var dist_path;
 if (debug) {
     dist_path = pkginfo.dist.path;
 } else {
-    dist_path = exec_sync(
+    dist_path = child_process.execSync(
         "python -c '" +
         "from " + settingsFile + " import *;" +
         "print(" + staticDistVariable + ")" +
         "'"
-    );
+    ).toString().trim();
 }
 
 gulp.task('default', ['build:scripts', 'build:styles']);

--- a/package.json
+++ b/package.json
@@ -79,7 +79,9 @@
     "browserify": "~11.0.0",
     "bootstrap": "~3.3.5",
     "bootstrap-select": "~1.7.3",
-    "bower": "~1.4.1",
-    "exec-sync": "~0.1.6"
+    "bower": "~1.4.1"
+  },
+  "engines": {
+      "node": ">0.12"
   }
 }


### PR DESCRIPTION
As exec-sync package is no longer supported (latest release was 3 years
ago: https://www.npmjs.com/package/exec-sync) and required functionality
was implemented in nodejs 0.12, corresponding changes to this project
were made.

```
- require nodejs v0.12 or higher
- drop exec-sync dependency
- use child_process.execSync instead
```
